### PR TITLE
Add ability to modify the text through preferences (Add-on Manager), and refactor code to use the Add-on SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Useful to distinguish between different profiles, without fiddling with launcher
 Usage
 -----
 
-1. Go to `about:config` 
-2. add a new `string` value named `extensions.custom-badge.value` 
-   and set it to the desired text (e.g., "Fun", "Work" etc.)
+1. Go to `about:addons` 
+2. Find the custom-badge addon under the `Extensions` tab,
+   click on `Preferences`, and set the Badge Text to the
+   desired text (e.g., "Fun", "Work" etc.)
 3. ???
 4. PROFIT!
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,41 +1,12 @@
- const {Cc,Ci} = require("chrome");
+const {Cc,Ci} = require("chrome");
 
+var { PrefsTarget } = require("sdk/preferences/event-target");
+var target = PrefsTarget({ branchName: "extensions." + require("sdk/self").id + "." });
+var simplePrefs = require('sdk/simple-prefs');
 
-var prefs = Cc["@mozilla.org/preferences-service;1"]
-              .getService(Ci.nsIPrefBranch);
+var dock = Cc["@mozilla.org/widget/macdocksupport;1"]
+             .getService(Ci.nsIMacDockSupport);
 
-//var myPrefs = prefs.getBranch("extensions.custom-badge.");
-//myPrefs.addObserver("extensions.custom-badge.", );
-
-var myPrefObserver = {
-  dock:  Cc["@mozilla.org/widget/macdocksupport;1"]
-		.getService(Ci.nsIMacDockSupport),
-
-  prefService: null,	
-  register: function() {
-    this.prefService = Cc["@mozilla.org/preferences-service;1"]
-                                .getService(Ci.nsIPrefService);
-    
-
-    this.branch = this.prefService.getBranch("extensions.custom-badge.");
-    if (this.branch.prefHasUserValue("value")) {
-		this.dock.badgeText = this.branch.getCharPref("value");
-	}
-    this.branch.addObserver("", this, false);
-  },
-
-  unregister: function() {
-    this.branch.removeObserver("", this);
-  },
-
-  observe: function(aSubject, aTopic, aData) {
-    // aSubject is the nsIPrefBranch we're observing (after appropriate QI)
-    // aData is the name of the pref that's been changed (relative to aSubject)
-    switch (aData) {
-      case "value":
-        this.dock.badgeText = this.branch.getCharPref("value");
-        break;
-    }
-  }
-}
-myPrefObserver.register();
+target.on("badgeText", function(prefName) {
+  dock.badgeText = target.prefs[prefName];
+});

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,10 +2,13 @@ const {Cc,Ci} = require("chrome");
 
 var { PrefsTarget } = require("sdk/preferences/event-target");
 var target = PrefsTarget({ branchName: "extensions." + require("sdk/self").id + "." });
-var simplePrefs = require('sdk/simple-prefs');
 
 var dock = Cc["@mozilla.org/widget/macdocksupport;1"]
              .getService(Ci.nsIMacDockSupport);
+
+exports.main = function(o,c) {
+  dock.badgeText = target.prefs['badgeText'];
+};
 
 target.on("badgeText", function(prefName) {
   dock.badgeText = target.prefs[prefName];

--- a/package.json
+++ b/package.json
@@ -5,5 +5,11 @@
   "description": "Overlays a custom string on the Firefox icon",
   "author": "evacchi",
   "license": "MPL 2.0",
-  "version": "0.1.1"
+  "version": "0.1.2",
+  "preferences": [{
+    "name": "badgeText",
+    "title": "Badge Text",
+    "type": "string",
+    "value": ""
+  }]
 }


### PR DESCRIPTION
Hi @evacchi , dunno if you're still going to stick with the text label idea, given the discussion in https://github.com/evacchi/firefox-custom-badge/issues/1, but... this finally adds the ability to edit the text through a preference system. Much easier than having to go to `about:config`, and then manually creating the string value or editing it yourself.

I realize this is a major rewrite (only 2 things have stayed the same - the `require("chrome")` line, and the (very appreciated) fact that the info about how to get at the dock is still there), so just let me know what you think. Thanks.
